### PR TITLE
Deceptive message publishing

### DIFF
--- a/06. Resiliency And High Availability/Server/CarRentalSystem/Messages/MessagesHostedService.cs
+++ b/06. Resiliency And High Availability/Server/CarRentalSystem/Messages/MessagesHostedService.cs
@@ -48,7 +48,7 @@
 
             foreach (var message in messages)
             {
-                this.publisher.Publish(message.Data, message.Type);
+                this.publisher.Publish(message.Data, message.Type).GetAwaiter().GetResult();
 
                 message.MarkAsPublished();
 


### PR DESCRIPTION
Not awaiting the message publishing doesn't throw an exception when RabbitMQ is down, which leads to false marking the message as published in the database.